### PR TITLE
Fix typo in CAN_ID.json

### DIFF
--- a/CAN_ID.json
+++ b/CAN_ID.json
@@ -125,7 +125,7 @@
         "88": {
             "source"     :"chasis",
             "execution"  :"power train",
-            "name"       :"steeering wheel operation position",
+            "name"       :"steering wheel operation position",
             "level"      :"command",
             "type"       :"operation",
             "period"     :10,


### PR DESCRIPTION
I found a typo when I used PASTA.